### PR TITLE
feat: advance the clock by a timer's full duration when passed

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,17 +6,19 @@
       "name": "@johngw/timeline",
       "dependencies": {
         "@johngw/outerface": "^2.0.2",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "tslib": "^2.8.1",
       },
       "devDependencies": {
-        "@commitlint/cli": "21.0.1",
-        "@commitlint/config-conventional": "21.0.1",
+        "@commitlint/cli": "21.0.2",
+        "@commitlint/config-conventional": "21.0.2",
         "@commitlint/types": "21.0.1",
+        "@sinonjs/fake-timers": "^15.4.0",
         "@types/bun": "latest",
         "@types/js-yaml": "4.0.9",
+        "@types/sinonjs__fake-timers": "^15.0.1",
         "husky": "9.1.7",
-        "lint-staged": "17.0.5",
+        "lint-staged": "17.0.7",
         "prettier": "3.8.3",
         "rimraf": "6.1.3",
         "typescript": "6.0.3",
@@ -28,9 +30,9 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@commitlint/cli": ["@commitlint/cli@21.0.1", "", { "dependencies": { "@commitlint/format": "^21.0.1", "@commitlint/lint": "^21.0.1", "@commitlint/load": "^21.0.1", "@commitlint/read": "^21.0.1", "@commitlint/types": "^21.0.1", "tinyexec": "^1.0.0", "yargs": "^18.0.0" }, "bin": { "commitlint": "cli.js" } }, "sha512-8vq10krmbJwBkvzXKhbs4o4JQEVscd3pqOlWuDUaDBwbeL694/P33UC29tZQFTAgPU9fVJ2+f2m3zw16yKWxHg=="],
+    "@commitlint/cli": ["@commitlint/cli@21.0.2", "", { "dependencies": { "@commitlint/format": "^21.0.1", "@commitlint/lint": "^21.0.2", "@commitlint/load": "^21.0.2", "@commitlint/read": "^21.0.2", "@commitlint/types": "^21.0.1", "tinyexec": "^1.0.0", "yargs": "^18.0.0" }, "bin": { "commitlint": "cli.js" } }, "sha512-YMmfLbqBg+ZRvvmPhc+cilSQFrh/AgzVgCT1U/OifmUZEwPbvCtA8rN//YNaF9d5eoZphxVMGYtmwA2QgQORgg=="],
 
-    "@commitlint/config-conventional": ["@commitlint/config-conventional@21.0.1", "", { "dependencies": { "@commitlint/types": "^21.0.1", "conventional-changelog-conventionalcommits": "^9.2.0" } }, "sha512-gRorrkfWOh/+V5X8GYWWbQvrzPczopGMS4CCNrQdHkK4xWElv82BDvIsDhJZWTlI7TazOlYea6VATufCsFs+sw=="],
+    "@commitlint/config-conventional": ["@commitlint/config-conventional@21.0.2", "", { "dependencies": { "@commitlint/types": "^21.0.1", "conventional-changelog-conventionalcommits": "^9.2.0" } }, "sha512-P/ZRhryQmkj0Z0dY9FOoRwe3xkwJyyAdtXwt01NT2kuZttcG2CNYp1q5Ci3u+nDT2jcbJRw2kt13Czl1qKNPfg=="],
 
     "@commitlint/config-validator": ["@commitlint/config-validator@21.0.1", "", { "dependencies": { "@commitlint/types": "^21.0.1", "ajv": "^8.11.0" } }, "sha512-Zd2UFdndeMMaW2O96HK0tdfT4gOImUvidMpAd/pws2zZ4m1nrAZ/9b/v2JYuE8fs86GpXv9F7LNaIuCIWhY+pA=="],
 
@@ -40,25 +42,25 @@
 
     "@commitlint/format": ["@commitlint/format@21.0.1", "", { "dependencies": { "@commitlint/types": "^21.0.1", "picocolors": "^1.1.1" } }, "sha512-ksmG2+cHGtuDPQQbhBbC4unwm444+6TiPw0d1bKf67hntgZqZ8E0g1MuYKUuyT5IH4IMmXZhKq22/Z3jBvtQIw=="],
 
-    "@commitlint/is-ignored": ["@commitlint/is-ignored@21.0.1", "", { "dependencies": { "@commitlint/types": "^21.0.1", "semver": "^7.6.0" } }, "sha512-iNDP8SFdw8JEkM0CHZ2XFnhTN4Zg5jKUY2d8kBOSFrI2aA+3YJI7fcqVpfgbpJ9xtxFVYpi+DBATU5AvhoTq8g=="],
+    "@commitlint/is-ignored": ["@commitlint/is-ignored@21.0.2", "", { "dependencies": { "@commitlint/types": "^21.0.1", "semver": "^7.6.0" } }, "sha512-H5z4t8PC9tUsmZ/o+EptM3Nq8sTFtskAShdcqxCoyzklW5eaVT5xbrDAET2uypzir9Vsj4ZZmBtyKjYe2XqgeQ=="],
 
-    "@commitlint/lint": ["@commitlint/lint@21.0.1", "", { "dependencies": { "@commitlint/is-ignored": "^21.0.1", "@commitlint/parse": "^21.0.1", "@commitlint/rules": "^21.0.1", "@commitlint/types": "^21.0.1" } }, "sha512-gF+iYtUw1gBG3HUH9z3VxwUjGg2R2G5j+nmvPs8aIeYkiB7TtneBu3wO85I0bUl93bYNsvsCNI9Nte2fmDUMww=="],
+    "@commitlint/lint": ["@commitlint/lint@21.0.2", "", { "dependencies": { "@commitlint/is-ignored": "^21.0.2", "@commitlint/parse": "^21.0.2", "@commitlint/rules": "^21.0.2", "@commitlint/types": "^21.0.1" } }, "sha512-PnUmLYGeGLfW8oVatR9KpNxSHYAnJOEWlMZzfdeFOUq6WUrFx1fGQaWCWJqMoIll/xPM+GdfJV+tKHZVHhl0Fg=="],
 
-    "@commitlint/load": ["@commitlint/load@21.0.1", "", { "dependencies": { "@commitlint/config-validator": "^21.0.1", "@commitlint/execute-rule": "^21.0.1", "@commitlint/resolve-extends": "^21.0.1", "@commitlint/types": "^21.0.1", "cosmiconfig": "^9.0.1", "cosmiconfig-typescript-loader": "^6.1.0", "es-toolkit": "^1.46.0", "is-plain-obj": "^4.1.0", "picocolors": "^1.1.1" } }, "sha512-Btg1q1mKmiihN4W3x0EsPDrJMOQfMa9NIqlzlJyXAfxvsOGdGXOW5p3R3RcSxDCaY7JabY9flIl+Om1af3PSrw=="],
+    "@commitlint/load": ["@commitlint/load@21.0.2", "", { "dependencies": { "@commitlint/config-validator": "^21.0.1", "@commitlint/execute-rule": "^21.0.1", "@commitlint/resolve-extends": "^21.0.1", "@commitlint/types": "^21.0.1", "cosmiconfig": "^9.0.1", "cosmiconfig-typescript-loader": "^6.1.0", "es-toolkit": "^1.46.0", "is-plain-obj": "^4.1.0", "picocolors": "^1.1.1" } }, "sha512-lwUE70hN0/qE/ZRROhbaX65ly/FF12DrqfReLCESo37M0OQCFAf2jRS+2tSCSORq+bm4Kdju7qNDj46uc1QzTA=="],
 
-    "@commitlint/message": ["@commitlint/message@21.0.1", "", {}, "sha512-R3dVQeJQ0B6yqrZEjkUHD4r7UJYLV9Lvk2xs3PTOmtWk2G3mI6Xgc+YdRxL1PwcDfBiUjv2SkIkW4AUc976w1w=="],
+    "@commitlint/message": ["@commitlint/message@21.0.2", "", {}, "sha512-5n4aqHGD/FNnom/D5L8i7cYtV+xjuXcBL832C3w9VglEsZzIsoHpJsvxzJ7cgiOsOdc/2jU4t5+7qMHh7GBX3g=="],
 
-    "@commitlint/parse": ["@commitlint/parse@21.0.1", "", { "dependencies": { "@commitlint/types": "^21.0.1", "conventional-changelog-angular": "^8.2.0", "conventional-commits-parser": "^6.3.0" } }, "sha512-oh/nCSOqdoeQNA1tO8aAmxkq5EBo8/NzcFQRvv66AWc9HpED28sL2iSicCKU6hPintWuscL6BJEWi77Wq1LPMQ=="],
+    "@commitlint/parse": ["@commitlint/parse@21.0.2", "", { "dependencies": { "@commitlint/types": "^21.0.1", "conventional-changelog-angular": "^8.2.0", "conventional-commits-parser": "^6.3.0" } }, "sha512-QVZJhGHTm+oiuWyEKOCTQ0ZM3mfJ0eGWFeHuj7WzSKEth+UukcCHac9GD8pgdFlg/qGkFWOtyaNd1T8REgagaw=="],
 
-    "@commitlint/read": ["@commitlint/read@21.0.1", "", { "dependencies": { "@commitlint/top-level": "^21.0.1", "@commitlint/types": "^21.0.1", "git-raw-commits": "^5.0.0", "tinyexec": "^1.0.0" } }, "sha512-pMEu4lbpC8W0ZgKJj2U6WaobXIZWdFlULpIEewYhkPXx+WZcnoO53YrVPc7QErQuNolq2Me8dP58Wu7YAVXVOA=="],
+    "@commitlint/read": ["@commitlint/read@21.0.2", "", { "dependencies": { "@commitlint/top-level": "^21.0.2", "@commitlint/types": "^21.0.1", "git-raw-commits": "^5.0.0", "tinyexec": "^1.0.0" } }, "sha512-BtsrnLVycSSKf4Q0gMch4giCj5NNlmcbhc8ra5vONgGtP2IjRDo33bEFtr5Pm+2N+5fXGWb2MksWPrspPfdhdw=="],
 
     "@commitlint/resolve-extends": ["@commitlint/resolve-extends@21.0.1", "", { "dependencies": { "@commitlint/config-validator": "^21.0.1", "@commitlint/types": "^21.0.1", "es-toolkit": "^1.46.0", "global-directory": "^5.0.0", "resolve-from": "^5.0.0" } }, "sha512-0DhjYWL6uYrY16Efa032fYk3woGJDU4AGWiG1XXltT9AMUNYKyb5cIZU2ivbaMZ3+kKFqUjikD2cjh66Sbh/Sg=="],
 
-    "@commitlint/rules": ["@commitlint/rules@21.0.1", "", { "dependencies": { "@commitlint/ensure": "^21.0.1", "@commitlint/message": "^21.0.1", "@commitlint/to-lines": "^21.0.1", "@commitlint/types": "^21.0.1" } }, "sha512-VMooYpz4nJg7xlaUso6CCOWEz8D/ChkvsvZUMARcoJ1ZpfKPyFCGrHNha2tbsETNAb6ErgiRuCr2DvghrvPDYQ=="],
+    "@commitlint/rules": ["@commitlint/rules@21.0.2", "", { "dependencies": { "@commitlint/ensure": "^21.0.1", "@commitlint/message": "^21.0.2", "@commitlint/to-lines": "^21.0.1", "@commitlint/types": "^21.0.1" } }, "sha512-k6tQ69Td7t2qUSIbik8D3TL1q3ZJpkEbV+yLogDzCRAdOxJm4ndhtBNREsLA1/puRfWvzS9eioF2w43WT+hHgQ=="],
 
     "@commitlint/to-lines": ["@commitlint/to-lines@21.0.1", "", {}, "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw=="],
 
-    "@commitlint/top-level": ["@commitlint/top-level@21.0.1", "", { "dependencies": { "escalade": "^3.2.0" } }, "sha512-4esUYqzY7K0FCgcJ/1xWEZekV7Ch4yZT1+xjEb7KzqbJ05XEkxHVsTfC8ADKNNtlCE2pj98KEbPGZWw9WwEnVw=="],
+    "@commitlint/top-level": ["@commitlint/top-level@21.0.2", "", { "dependencies": { "escalade": "^3.2.0" } }, "sha512-s9KKM+e+mXgFeIh4n7KmOGAVT3mkJ3Fp1bBYHIK5pjeUwlEMzp/tZfb5u0Poa680AsQTXMEMRxZi1vQ9m2X5ug=="],
 
     "@commitlint/types": ["@commitlint/types@21.0.1", "", { "dependencies": { "conventional-commits-parser": "^6.3.0", "picocolors": "^1.1.1" } }, "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg=="],
 
@@ -70,11 +72,17 @@
 
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
 
+    "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
+
+    "@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/node": ["@types/node@20.17.6", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ=="],
+
+    "@types/sinonjs__fake-timers": ["@types/sinonjs__fake-timers@15.0.1", "", {}, "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -162,7 +170,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
@@ -170,7 +178,7 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "lint-staged": ["lint-staged@17.0.5", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.1.2" }, "optionalDependencies": { "yaml": "^2.8.4" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw=="],
+    "lint-staged": ["lint-staged@17.0.7", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA=="],
 
     "listr2": ["listr2@10.2.1", "", { "dependencies": { "cli-truncate": "^5.2.0", "eventemitter3": "^5.0.4", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^10.0.0" } }, "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q=="],
 
@@ -224,9 +232,11 @@
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+    "tinyexec": ["tinyexec@1.2.2", "", {}, "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
@@ -242,15 +252,17 @@
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
-    "@commitlint/read/tinyexec": ["tinyexec@1.2.2", "", {}, "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g=="],
+    "@commitlint/read/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "cli-truncate/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
+    "cosmiconfig/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "lint-staged/tinyexec": ["tinyexec@1.2.2", "", {}, "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g=="],
+    "lint-staged/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 

--- a/package.json
+++ b/package.json
@@ -37,13 +37,15 @@
   },
   "homepage": "https://github.com/jg-wright/timeline#readme",
   "devDependencies": {
-    "@commitlint/cli": "21.0.1",
-    "@commitlint/config-conventional": "21.0.1",
+    "@commitlint/cli": "21.0.2",
+    "@commitlint/config-conventional": "21.0.2",
     "@commitlint/types": "21.0.1",
+    "@sinonjs/fake-timers": "^15.4.0",
     "@types/bun": "latest",
     "@types/js-yaml": "4.0.9",
+    "@types/sinonjs__fake-timers": "^15.0.1",
     "husky": "9.1.7",
-    "lint-staged": "17.0.5",
+    "lint-staged": "17.0.7",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
     "typescript": "6.0.3"
@@ -60,7 +62,7 @@
   },
   "dependencies": {
     "@johngw/outerface": "^2.0.2",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "tslib": "^2.8.1"
   }
 }

--- a/src/TimelineItem/TimelineItemTimer.ts
+++ b/src/TimelineItem/TimelineItemTimer.ts
@@ -32,6 +32,17 @@ export class TimelineItemTimer extends TimelineItem<TimelineTimer> {
     return super.onReach()
   }
 
+  /**
+   * Passing a timer advances the clock by the timer's full duration — not
+   * the 1-frame-per-character default. This is what makes a `Tn` consume
+   * `n` frames of virtual time when a timeline is iterated, so a consumer
+   * never has to wait on {@link TimelineTimer.promise} (which, on a virtual
+   * clock, would deadlock: nothing advances the clock while you await it).
+   */
+  override async onPass() {
+    await this.clock.advance(this.#timer.ms)
+  }
+
   get() {
     return this.#timer
   }

--- a/test/Timeline.test.ts
+++ b/test/Timeline.test.ts
@@ -126,6 +126,13 @@ test('consuming a timeline advances its clock one frame per dash', async () => {
   expect(timeline.clock.now).toBe(6)
 })
 
+test('passing a timer advances the clock by its full duration', async () => {
+  const timeline = Timeline.create('--T10--|')
+  await asyncIterableToArray(timeline)
+  // '-'(1) '-'(1) 'T10'(10) '-'(1) '-'(1) '|'(1) => 15 frames.
+  expect(timeline.clock.now).toBe(15)
+})
+
 test('timers finish deterministically off the shared clock, no real time', async () => {
   const clock = new Clock()
   const timeline = Timeline.create('T3--|', { clock })

--- a/test/streamBridge.test.ts
+++ b/test/streamBridge.test.ts
@@ -1,0 +1,211 @@
+/**
+ * End-to-end proof that a timeline and real-timer code (a transformer using
+ * `setInterval`) can share ONE virtual clock, so their timing lines up
+ * deterministically with no wall-clock dependency.
+ *
+ * This builds minimal `fromTimeline` / `sampleTime` / `expectTimeline`
+ * pieces — mirroring `@johngw/stream-test` — with the three fixes needed to
+ * make the pull-based timelines work on a virtual clock:
+ *
+ *   1. The source never `await`s a timer's promise (that deadlocks on a
+ *      virtual clock). Passing the timer advances the clock by its duration
+ *      (see `TimelineItemTimer.onPass`), so the source just moves on.
+ *   2. Only the source drives the clock. The expectation reads the same
+ *      clock through a read-only view whose `advance` is a no-op, so the two
+ *      timelines don't double-advance shared time.
+ *   3. The expectation yields with a microtask, never a (possibly faked)
+ *      `setTimeout`, so it can't deadlock against the fake timers.
+ */
+import FakeTimers from '@sinonjs/fake-timers'
+import { expect, test } from 'bun:test'
+import {
+  type Clockable,
+  type ParsedTimelineItem,
+  Timeline,
+  TimelineItemClose,
+  TimelineItemDash,
+  TimelineItemTimer,
+} from '../src/index.js'
+
+/** The transformer under test, from the README example. */
+function sampleTime<T>(ms: number): TransformStream<T, T> {
+  let buffer: T
+  let hasSample = false
+  let interval: ReturnType<typeof setInterval>
+
+  return new TransformStream<T, T>({
+    start(controller) {
+      interval = setInterval(() => {
+        if (hasSample) controller.enqueue(buffer)
+      }, ms)
+    },
+    transform(chunk) {
+      hasSample = true
+      buffer = chunk
+    },
+    // `flush` covers normal completion; the real transformer also has a
+    // `cancel`, omitted here as this lib's `Transformer` type predates it.
+    flush: () => clearInterval(interval),
+  })
+}
+
+/** The clock object returned by `FakeTimers.install`. */
+type FakeClock = ReturnType<typeof FakeTimers.install>
+
+/** A `Clockable` backed by fake timers; one frame == one fake millisecond. */
+function fakeClockable(fake: FakeClock): Clockable {
+  return {
+    get now() {
+      return fake.now
+    },
+    wait: (frames) =>
+      new Promise((resolve) => {
+        fake.setTimeout(() => resolve(), frames)
+      }),
+    // Step one frame at a time so an interval's `enqueue` is delivered and
+    // matched before the clock moves on — keeping timing checks exact.
+    advance: async (frames = 1) => {
+      for (let i = 0; i < frames; i++) await fake.tickAsync(1)
+    },
+  }
+}
+
+/** A read-only view of a clock: reads its time, but never advances it. */
+function readonlyClock(clock: Clockable): Clockable {
+  return {
+    get now() {
+      return clock.now
+    },
+    wait: (frames) => clock.wait(frames),
+    advance: () => {},
+  }
+}
+
+/** Minimal `fromTimeline`: a source ReadableStream driven by the clock. */
+function fromTimeline(
+  timelineString: string,
+  clock: Clockable,
+): ReadableStream<number> {
+  const timeline = Timeline.create(timelineString, { clock })
+  return new ReadableStream<number>({
+    async pull(controller) {
+      const { done, value } = await timeline.next()
+      if (done || value instanceof TimelineItemClose) return controller.close()
+      // A dash and a timer both just spend time (their `onPass` advances the
+      // clock); move on without emitting.
+      if (
+        value instanceof TimelineItemDash ||
+        value instanceof TimelineItemTimer
+      )
+        return this.pull!(controller)
+      controller.enqueue(value!.get() as number)
+    },
+  })
+}
+
+/** Minimal `expectTimeline`: a sink that matches chunks against the marble. */
+function expectTimeline(
+  timelineString: string,
+  clock: Clockable,
+  check: (expected: unknown, chunk: unknown) => void,
+): WritableStream<number> {
+  // Read the shared clock, but never advance it — only the source drives.
+  const timeline = Timeline.create(timelineString, {
+    clock: readonlyClock(clock),
+  })
+  let nextResult = next()
+
+  async function next(): Promise<
+    IteratorResult<ParsedTimelineItem, undefined>
+  > {
+    const result = await timeline.next()
+    if (result.value instanceof TimelineItemDash) return next()
+    return result
+  }
+
+  async function consume(chunk: number): Promise<void> {
+    const { done, value } = await nextResult
+    if (done) throw new Error(`received an extra value: ${chunk}`)
+    if (value instanceof TimelineItemTimer) {
+      const timer = value.get()
+      await Promise.resolve() // yield — never a (faked) timer
+      if (!timer.finished)
+        throw new Error(
+          `expected a ${timer.ms}-frame timer to have finished; ${timer.timeLeft} frames left`,
+        )
+      nextResult = next()
+      return consume(chunk) // re-match this chunk against the next item
+    }
+    check(value!.get(), chunk)
+    nextResult = next()
+  }
+
+  return new WritableStream<number>({
+    write: (chunk) => consume(chunk),
+    async close() {
+      if (timeline.hasUnfinishedItems())
+        throw new Error('the timeline expected more values')
+    },
+  })
+}
+
+test('a timeline and a setInterval transformer share one clock, deterministically', async () => {
+  const fake = FakeTimers.install({
+    toFake: [
+      'setInterval',
+      'clearInterval',
+      'setTimeout',
+      'clearTimeout',
+      'Date',
+    ],
+  })
+
+  try {
+    const clock = fakeClockable(fake)
+    const matched: Array<[unknown, unknown]> = []
+
+    await fromTimeline('1-T40--------2--T20--|', clock)
+      .pipeThrough(sampleTime<number>(20))
+      .pipeTo(
+        expectTimeline('T20-1-T20-1-T20-2---', clock, (expected, chunk) => {
+          matched.push([expected, chunk])
+          expect(chunk).toBe(expected)
+        }),
+      )
+
+    // sampleTime(20) emits its latest value every 20 frames: 1 @20, 1 @40,
+    // 2 @60 — exactly what the expectation marble describes.
+    expect(matched).toEqual([
+      [1, 1],
+      [1, 1],
+      [2, 2],
+    ])
+  } finally {
+    fake.uninstall()
+  }
+})
+
+test('the expectation fails when a value arrives before its timer has elapsed', async () => {
+  const fake = FakeTimers.install({
+    toFake: [
+      'setInterval',
+      'clearInterval',
+      'setTimeout',
+      'clearTimeout',
+      'Date',
+    ],
+  })
+
+  try {
+    const clock = fakeClockable(fake)
+
+    const run = fromTimeline('1-T40--|', clock)
+      .pipeThrough(sampleTime<number>(20))
+      // Demands 50 frames before the first value, but it arrives at frame 20.
+      .pipeTo(expectTimeline('T50-1', clock, () => {}))
+
+    await expect(run).rejects.toThrow(/timer to have finished/)
+  } finally {
+    fake.uninstall()
+  }
+})


### PR DESCRIPTION
Follow-up to the virtual-clock work released in 5.0.0.

## Why

Consuming a timeline on a virtual clock needs timers to *spend* their time as they're passed. Previously `onPass` advanced the clock by the token's character count (`T40` → 3 frames), and the only way to realise the 40-frame duration was to `await TimelineTimer.promise`. On a virtual clock that **deadlocks**: the promise resolves when the clock advances, but nothing advances it while you're blocked awaiting it.

## What

- `TimelineItemTimer.onPass()` now advances the clock by the timer's full duration (`T40` → 40 frames). A pull-based consumer drives timing just by iterating — it never awaits the timer promise.
- Adds `test/streamBridge.test.ts`: an end-to-end proof that a timeline and a `setInterval`-based transformer (`sampleTime`) share one `@sinonjs/fake-timers`-backed `Clockable` and line up deterministically (`1 @20, 1 @40, 2 @60`), plus a negative test showing the timing barrier rejects a value that arrives too early.

## Notes

This is the linchpin for porting `@johngw/stream-test` to the virtual clock. With it, the consumer fixes are small: `fromTimeline` drops `await timer.promise` (just moves on), and `expectTimeline` reads the shared clock through a no-op-`advance` view and yields with a microtask instead of a (fakeable) `setTimeout`.

Behavioural change to `onPass` timing; safe within the 5.x line as timers are meant to represent durations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)