### PR TITLE
feat: default timelines to a shared ambient clock, overridable per timeline

### DIFF
--- a/src/Clock.ts
+++ b/src/Clock.ts
@@ -50,6 +50,38 @@ export interface Clockable {
  * const expected = Timeline.create('-----T10-2--', { clock })
  * ```
  */
+let defaultClock: Clockable | undefined
+
+/**
+ * The ambient {@link Clockable} a {@link Timeline} uses when none is passed
+ * explicitly.
+ *
+ * @remarks
+ * Sharing a clock is almost always what you want — a source, the code under
+ * test, and an expectation all need to advance together — so timelines
+ * default to this single ambient clock rather than a fresh one each. Replace
+ * it with {@link setDefaultClock} (e.g. a fake-timers-backed clock in a
+ * test), or override per timeline with `Timeline.create(str, { clock })`.
+ */
+export function getDefaultClock(): Clockable {
+  return (defaultClock ??= new Clock())
+}
+
+/**
+ * Sets the ambient {@link Clockable} returned by {@link getDefaultClock} and
+ * used by new timelines without an explicit `clock`.
+ *
+ * @returns a function that restores the previously-set default. Pair it with
+ * a test's teardown so the ambient clock doesn't leak between tests.
+ */
+export function setDefaultClock(clock: Clockable): () => void {
+  const previous = defaultClock
+  defaultClock = clock
+  return () => {
+    defaultClock = previous
+  }
+}
+
 export class Clock implements Clockable {
   #now = 0
   #waiters: { at: number; resolve: () => void }[] = []

--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -1,5 +1,5 @@
 import { asyncIterableReduce, search } from './util.js'
-import { Clock, type Clockable } from './Clock.js'
+import { getDefaultClock, type Clockable } from './Clock.js'
 import { TimelineItemBoolean } from './TimelineItem/TimelineItemBoolean.js'
 import { TimelineItemClose } from './TimelineItem/TimelineItemClose.js'
 import { TimelineItemError } from './TimelineItem/TimelineItemError.js'
@@ -37,9 +37,9 @@ export type DefaultParsers = typeof DefaultParsers
  */
 export interface TimelineOptions {
   /**
-   * The {@link Clockable} that drives this timeline's timing. Pass the same
-   * instance to multiple timelines to advance them in lockstep so their
-   * timers line up deterministically. Defaults to a fresh {@link Clock}.
+   * The {@link Clockable} that drives this timeline's timing. Defaults to the
+   * shared ambient clock ({@link getDefaultClock}), so timelines coordinate
+   * by default. Pass an explicit clock to override it for this timeline.
    */
   clock?: Clockable
 }
@@ -82,7 +82,7 @@ export class Timeline<
     options: TimelineOptions = {},
   ) {
     this.#Parsers = Parsers
-    this.#clock = options.clock ?? new Clock()
+    this.#clock = options.clock ?? getDefaultClock()
     this.#unparsed = timeline.trim()
     this.#parsed = this.#parse()
   }

--- a/src/TimelineItem/TimelineItem.ts
+++ b/src/TimelineItem/TimelineItem.ts
@@ -1,4 +1,4 @@
-import { Clock, type Clockable } from '../Clock.js'
+import { getDefaultClock, type Clockable } from '../Clock.js'
 import type { Outerface } from '@johngw/outerface'
 
 /**
@@ -8,7 +8,7 @@ export interface TimelineItemOptions {
   /**
    * The {@link Clockable} driving this item's timing. {@link Timeline}
    * passes its shared clock here so all of its items advance together.
-   * Defaults to a fresh, standalone {@link Clock}.
+   * Defaults to the shared ambient clock ({@link getDefaultClock}).
    */
   clock?: Clockable
 }
@@ -24,7 +24,10 @@ export abstract class TimelineItem<T> {
     return this.#rawValue
   }
 
-  constructor(rawValue: string, { clock = new Clock() }: TimelineItemOptions) {
+  constructor(
+    rawValue: string,
+    { clock = getDefaultClock() }: TimelineItemOptions,
+  ) {
     this.#rawValue = rawValue
     this.clock = clock
   }

--- a/src/TimelineItem/TimelineItemTimer.ts
+++ b/src/TimelineItem/TimelineItemTimer.ts
@@ -1,4 +1,4 @@
-import { Clock, type Clockable } from '../Clock.js'
+import { getDefaultClock, type Clockable } from '../Clock.js'
 import { outerface } from '@johngw/outerface'
 import {
   TimelineItem,
@@ -38,9 +38,13 @@ export class TimelineItemTimer extends TimelineItem<TimelineTimer> {
    * `n` frames of virtual time when a timeline is iterated, so a consumer
    * never has to wait on {@link TimelineTimer.promise} (which, on a virtual
    * clock, would deadlock: nothing advances the clock while you await it).
+   *
+   * Advanced one frame at a time (like {@link TimelineItem.dash}) so each
+   * frame yields control — letting a timeline sharing this clock interleave
+   * in lock-step rather than the source jumping the whole duration at once.
    */
   override async onPass() {
-    await this.clock.advance(this.#timer.ms)
+    for (let i = 0; i < this.#timer.ms; i++) await this.clock.advance(1)
   }
 
   get() {
@@ -85,7 +89,7 @@ export class TimelineTimer {
   readonly #ms: number
   readonly #clock: Clockable
 
-  constructor(ms: number, clock: Clockable = new Clock()) {
+  constructor(ms: number, clock: Clockable = getDefaultClock()) {
     this.#ms = ms
     this.#clock = clock
   }

--- a/test/Timeline.test.ts
+++ b/test/Timeline.test.ts
@@ -4,7 +4,9 @@ import {
   Clock,
   type Clockable,
   CloseTimeline,
+  getDefaultClock,
   NeverReachTimelineError,
+  setDefaultClock,
   Timeline,
   TimelineError,
   TimelineTimer,
@@ -18,6 +20,9 @@ import { beforeEach, expect, test } from 'bun:test'
 let timeline: Timeline
 
 beforeEach(() => {
+  // Reset the ambient clock so each test starts from a fresh frame 0 (it's a
+  // shared singleton by default).
+  setDefaultClock(new Clock())
   timeline = Timeline.create(
     '--1--{foo: bar}--[a,b]--true--T--false--F--null--N--E--E(err foo)--T10--X--<Date>-|',
   )
@@ -158,6 +163,31 @@ test('a shared clock keeps two timelines in lockstep', () => {
   const source = Timeline.create('--1--2------', { clock })
   const expected = Timeline.create('-----T10-2--', { clock })
   expect(source.clock).toBe(expected.clock)
+})
+
+test('timelines share the ambient clock by default', () => {
+  const a = Timeline.create('--1--')
+  const b = Timeline.create('--2--')
+  expect(a.clock).toBe(getDefaultClock())
+  expect(a.clock).toBe(b.clock)
+})
+
+test('an explicit clock overrides the ambient default', () => {
+  const clock = new Clock()
+  const timeline = Timeline.create('--1--', { clock })
+  expect(timeline.clock).toBe(clock)
+  expect(timeline.clock).not.toBe(getDefaultClock())
+})
+
+test('setDefaultClock swaps the ambient clock and can restore it', () => {
+  const original = getDefaultClock()
+  const replacement = new Clock()
+
+  const restore = setDefaultClock(replacement)
+  expect(Timeline.create('--1--').clock).toBe(replacement)
+
+  restore()
+  expect(getDefaultClock()).toBe(original)
 })
 
 test('a timeline accepts any Clockable, not just the built-in Clock', async () => {


### PR DESCRIPTION
## Why

Threading an explicit `{ clock }` through every `Timeline.create` proved to be the wrong default: in practice a source, the code under test, and an expectation *always* need the same clock, and forgetting to share it produced a class of confusing bugs (timer races, deadlocks). The fake-timers clock is already a process-global singleton anyway, so injection was fighting reality.

## What

- **Ambient default clock.** `getDefaultClock()` returns a shared clock; `Timeline` uses it unless given an explicit `{ clock }` (the override is unchanged). `setDefaultClock(clock)` swaps it and returns a **restore handle** to pair with test teardown, so the ambient clock doesn't leak between tests.
- **Per-frame timer `onPass`.** A passed `Tn` now advances one frame at a time (like `dash`) instead of jumping its whole duration in one synchronous step. This lets two timelines sharing a clock interleave in lock-step — fixing the "source races ahead of the expectation's barrier" failure on direct `source → expectation` timing.

## Tests

`tsc` (src + test projects) clean, build clean, `bun test` → **13 pass**, including new coverage: timelines share the ambient clock by default, an explicit clock overrides it, and `setDefaultClock` swaps/restores. Existing `streamBridge` end-to-end proof still passes.

## Note

Behavioural change: the default clock is now shared rather than fresh-per-`Timeline`. The `{ clock }` override restores per-timeline isolation where needed. Tests that assert absolute `clock.now` should reset the ambient clock in a `beforeEach` (`setDefaultClock(new Clock())`), as this PR's own tests now do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)